### PR TITLE
Created generic loop draft in utils, applied gmfss fortuna and rife to it and set up streamlined inputs on comfy nodes for those two, added function documentation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 from .other_nodes import Gradually_More_Denoise_KSampler
 
 #from models.esai import EISAI_VFI
-from models.gmfss_fortuna import GMFSS_Fortuna_VFI
+from models.gmfss_fortuna import GMFSS_Fortuna_VFI, GMFSS_Fortuna_VFI_Animation
 from models.ifrnet import IFRNet_VFI
 from models.ifunet import IFUnet_VFI
 from models.m2m import M2M_VFI
@@ -17,6 +17,7 @@ NODE_CLASS_MAPPINGS = {
     "KSampler Gradually Adding More Denoise (efficient)": Gradually_More_Denoise_KSampler,
     #"ESAI VFI": EISAI_VFI,
     "GMFSS Fortuna VFI": GMFSS_Fortuna_VFI,
+    "GMFSS Fortuna VFI (Animation)": GMFSS_Fortuna_VFI_Animation,
     "IFRNet VFI": IFRNet_VFI,
     "IFUnet VFI": IFUnet_VFI,
     "M2M VFI": M2M_VFI,

--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,8 @@ from models.m2m import M2M_VFI
 from models.rife import RIFE_VFI
 from models.sepconv import SepconvVFI
 from models.amt import AMT_VFI
-
+from utils import MakeInterpolationStateList
+    
 NODE_CLASS_MAPPINGS = {
     "KSampler Gradually Adding More Denoise (efficient)": Gradually_More_Denoise_KSampler,
     #"ESAI VFI": EISAI_VFI,
@@ -22,5 +23,6 @@ NODE_CLASS_MAPPINGS = {
     "M2M VFI": M2M_VFI,
     "RIFE VFI": RIFE_VFI,
     "Sepconv VFI": SepconvVFI,
-    "AMT VFI": AMT_VFI
+    "AMT VFI": AMT_VFI,
+    "Make Interpolation State List": MakeInterpolationStateList,
 }

--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 from .other_nodes import Gradually_More_Denoise_KSampler
 
 #from models.esai import EISAI_VFI
-from models.gmfss_fortuna import GMFSS_Fortuna_VFI, GMFSS_Fortuna_VFI_Animation
+from models.gmfss_fortuna import GMFSS_Fortuna_VFI
 from models.ifrnet import IFRNet_VFI
 from models.ifunet import IFUnet_VFI
 from models.m2m import M2M_VFI
@@ -17,7 +17,6 @@ NODE_CLASS_MAPPINGS = {
     "KSampler Gradually Adding More Denoise (efficient)": Gradually_More_Denoise_KSampler,
     #"ESAI VFI": EISAI_VFI,
     "GMFSS Fortuna VFI": GMFSS_Fortuna_VFI,
-    "GMFSS Fortuna VFI (Animation)": GMFSS_Fortuna_VFI_Animation,
     "IFRNet VFI": IFRNet_VFI,
     "IFUnet VFI": IFUnet_VFI,
     "M2M VFI": M2M_VFI,

--- a/models/gmfss_fortuna/__init__.py
+++ b/models/gmfss_fortuna/__init__.py
@@ -1,5 +1,5 @@
 import pathlib
-from utils import load_file_from_github_release, preprocess_frames, postprocess_frames, generic_frame_loop
+from utils import load_file_from_github_release, preprocess_frames, postprocess_frames, generic_frame_loop, InterpolationStateList
 import typing
 import torch
 import torch.nn as nn
@@ -101,7 +101,7 @@ class GMFSS_Fortuna_VFI:
         frames: torch.Tensor,
         clear_cache_after_n_frames = 10,
         multiplier: typing.SupportsInt = 2,
-        optional_interpolation_states: typing.Optional[list[bool]] = None   
+        optional_interpolation_states: InterpolationStateList = None   
     ):
         """
         Perform video frame interpolation using a given checkpoint model.

--- a/models/gmfss_fortuna/__init__.py
+++ b/models/gmfss_fortuna/__init__.py
@@ -86,6 +86,9 @@ class GMFSS_Fortuna_VFI:
                 "clear_cache_after_n_frames": ("INT", {"default": 10, "min": 1, "max": 1000}),
                 "multiplier": ("INT", {"default": 2, "min": 2, "max": 1000}),
             },
+            "optional": {
+                "optional_interpolation_states": ("INTERPOLATION_STATES", ),
+            }
         }
     
     RETURN_TYPES = ("IMAGE", )
@@ -98,6 +101,7 @@ class GMFSS_Fortuna_VFI:
         frames: torch.Tensor,
         clear_cache_after_n_frames = 10,
         multiplier: typing.SupportsInt = 2,
+        optional_interpolation_states: typing.Optional[list[bool]] = None   
     ):
         """
         Perform video frame interpolation using a given checkpoint model.
@@ -136,6 +140,7 @@ class GMFSS_Fortuna_VFI:
         
         args = [interpolation_model, scale]
         out = postprocess_frames(
-            generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args)
+            generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
+                               interpolation_states=optional_interpolation_states)
         )
         return (out,)

--- a/models/rife/__init__.py
+++ b/models/rife/__init__.py
@@ -2,7 +2,7 @@ from .rife_arch import IFNet
 import torch
 from torch.utils.data import DataLoader
 import pathlib
-from utils import load_file_from_github_release, preprocess_frames, postprocess_frames, generic_frame_loop
+from utils import load_file_from_github_release, preprocess_frames, postprocess_frames, generic_frame_loop, InterpolationStateList
 import typing
 
 MODEL_TYPE = pathlib.Path(__file__).parent.name
@@ -46,7 +46,7 @@ class RIFE_VFI:
         multiplier: typing.SupportsInt = 2,
         fast_mode = False,
         ensemble = False,
-        optional_interpolation_states: typing.Optional[list[bool]] = None    
+        optional_interpolation_states: InterpolationStateList = None    
     ):
         """
         Perform video frame interpolation using a given checkpoint model.

--- a/models/rife/__init__.py
+++ b/models/rife/__init__.py
@@ -26,8 +26,8 @@ class RIFE_VFI:
                 "frames": ("IMAGE", ),
                 "clear_cache_after_n_frames": ("INT", {"default": 10, "min": 1, "max": 1000}),
                 "multiplier": ("INT", {"default": 2, "min": 1}),
-                "fast_mode": ("BOOLEAN", {"default":False}),
-                "ensemble": ("BOOLEAN", {"default":False}),
+                "fast_mode": ("BOOLEAN", {"default":True}),
+                "ensemble": ("BOOLEAN", {"default":True}),
             },
             "optional": {
                 "optional_interpolation_states": ("INTERPOLATION_STATES", ),

--- a/models/rife/__init__.py
+++ b/models/rife/__init__.py
@@ -28,6 +28,9 @@ class RIFE_VFI:
                 "multiplier": ("INT", {"default": 2, "min": 1}),
                 "fast_mode": ("BOOLEAN", {"default":False}),
                 "ensemble": ("BOOLEAN", {"default":False}),
+            },
+            "optional": {
+                "optional_interpolation_states": ("INTERPOLATION_STATES", ),
             }
         }
     
@@ -42,7 +45,8 @@ class RIFE_VFI:
         clear_cache_after_n_frames = 10,
         multiplier: typing.SupportsInt = 2,
         fast_mode = False,
-        ensemble = False        
+        ensemble = False,
+        optional_interpolation_states: typing.Optional[list[bool]] = None    
     ):
         """
         Perform video frame interpolation using a given checkpoint model.
@@ -85,6 +89,7 @@ class RIFE_VFI:
         
         args = [interpolation_model, scale_list, fast_mode, ensemble]
         out = postprocess_frames(
-            generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args),
+            generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
+                               interpolation_states=optional_interpolation_states)
         )
         return (out,)

--- a/models/rife/__init__.py
+++ b/models/rife/__init__.py
@@ -2,7 +2,7 @@ from .rife_arch import IFNet
 import torch
 from torch.utils.data import DataLoader
 import pathlib
-from utils import load_file_from_github_release, preprocess_frames, postprocess_frames
+from utils import load_file_from_github_release, preprocess_frames, postprocess_frames, generic_frame_loop
 import typing
 
 MODEL_TYPE = pathlib.Path(__file__).parent.name
@@ -24,67 +24,67 @@ class RIFE_VFI:
             "required": {
                 "ckpt_name": (list(CKPT_NAME_VER_DICT.keys()), ),
                 "frames": ("IMAGE", ),
-                "batch_size": ("INT", {"default": 1, "min": 1, "max": 100}),
-                "multipler": ("INT", {"default": 2, "min": 1}),
-                "scale_factor": ("FLOAT", {"default": 1.0, "min": 0.1, "max": 100, "step": 0.1}),
-                "fast_mode": (["enabled", "disabled"], ),
-                "ensemble": (["enabled", "disabled"], {"default": "disabled"})
-            },
-            "optional": {
-                "optional_interpolation_states": ("INTERPOLATION_STATES", ),
+                "clear_cache_after_n_frames": ("INT", {"default": 10, "min": 1, "max": 1000}),
+                "multiplier": ("INT", {"default": 2, "min": 1}),
+                "fast_mode": ("BOOLEAN", {"default":False}),
+                "ensemble": ("BOOLEAN", {"default":False}),
             }
         }
     
     RETURN_TYPES = ("IMAGE", )
     FUNCTION = "vfi"
     CATEGORY = "ComfyUI-Frame-Interpolation/VFI"
-
+    
     def vfi(
         self,
-        ckpt_name: typing.AnyStr, 
-        frames: torch.Tensor, 
-        batch_size: typing.SupportsInt = 1,
-        multipler: typing.SupportsInt = 2,
-        scale_factor: typing.SupportsFloat = 1.0,
-        fast_mode: typing.AnyStr = "enabled",
-        ensemble: typing.AnyStr = "disabled",
-        optional_interpolation_states: typing.Optional[list[bool]] = None
+        ckpt_name: typing.AnyStr,
+        frames: torch.Tensor,
+        clear_cache_after_n_frames = 10,
+        multiplier: typing.SupportsInt = 2,
+        fast_mode = False,
+        ensemble = False        
     ):
-        fast_mode = fast_mode == "enabled"
-        ensemble = ensemble == "enabled"
-        scale_list = [8 / scale_factor, 4 / scale_factor, 2 / scale_factor, 1 / scale_factor]
-
+        """
+        Perform video frame interpolation using a given checkpoint model.
+    
+        Args:
+            ckpt_name (str): The name of the checkpoint model to use.
+            frames (torch.Tensor): A tensor containing input video frames.
+            clear_cache_after_n_frames (int, optional): The number of frames to process before clearing CUDA cache
+                to prevent memory overflow. Defaults to 10. Lower numbers are safer but mean more processing time.
+                How high you should set it depends on how many input frames there are, input resolution (after upscaling),
+                how many times you want to multiply them, and how long you're willing to wait for the process to complete.
+            multiplier (int, optional): The multiplier for each input frame. 60 input frames * 2 = 120 output frames. Defaults to 2.
+    
+        Returns:
+            tuple: A tuple containing the output interpolated frames.
+    
+        Note:
+            This method interpolates frames in a video sequence using a specified checkpoint model. 
+            It processes each frame sequentially, generating interpolated frames between them.
+    
+            To prevent memory overflow, it clears the CUDA cache after processing a specified number of frames.
+        """
+        
         model_path = load_file_from_github_release(MODEL_TYPE, ckpt_name)
-        global model
-        model = IFNet(arch_ver=CKPT_NAME_VER_DICT[ckpt_name])
-        model.load_state_dict(torch.load(model_path))
-        model.eval().cuda()
-
+        interpolation_model = IFNet(arch_ver=CKPT_NAME_VER_DICT[ckpt_name])
+        interpolation_model.load_state_dict(torch.load(model_path))
+        interpolation_model.eval().cuda()
+        
         frames = preprocess_frames(frames, "cuda")
+            
+        # Ensure proper tensor dimensions
+        frames = [frame.unsqueeze(0) for frame in frames]
         
-        frame_dict = {
-            str(i): frames[i].unsqueeze(0) for i in range(frames.shape[0])
-        }
-
-        if optional_interpolation_states is None:
-            interpolation_states = [True] * (frames.shape[0] - 1)
-        else:
-            interpolation_states = optional_interpolation_states
-
-        enabled_former_idxs = [i for i, state in enumerate(interpolation_states) if state]
-        former_idxs_loader = DataLoader(enabled_former_idxs, batch_size=batch_size)
+        def return_middle_frame(frame_0, frame_1, timestep, model, scale_list, in_fast_mode, in_ensemble):
+            return model(frame_0, frame_1, timestep, scale_list, in_fast_mode, in_ensemble)
         
-        for former_idxs_batch in former_idxs_loader:
-            for middle_i in range(1, multipler):
-                _middle_frames = model(
-                    frames[former_idxs_batch], 
-                    frames[former_idxs_batch + 1], 
-                    timestep=middle_i/multipler,
-                    scale_list=scale_list,
-                    fastmode=fast_mode,
-                    ensemble=ensemble
-                )
-                for i, former_idx in enumerate(former_idxs_batch):
-                    frame_dict[f'{former_idx}.{middle_i}'] = _middle_frames[i].unsqueeze(0)
-        out_frames = torch.cat([frame_dict[key] for key in sorted(frame_dict.keys())], dim=0)
-        return (postprocess_frames(out_frames), )
+        scale_factor = 1
+        # Intentionally leaving this in, as scale_factor could become a parameter
+        scale_list = [8 / scale_factor, 4 / scale_factor, 2 / scale_factor, 1 / scale_factor] 
+        
+        args = [interpolation_model, scale_list, fast_mode, ensemble]
+        out = postprocess_frames(
+            generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args),
+        )
+        return (out,)

--- a/utils.py
+++ b/utils.py
@@ -99,38 +99,40 @@ def generic_frame_loop(
         clear_cache_after_n_frames,
         multiplier: typing.SupportsInt,
         return_middle_frame_function,
-        *return_middle_frame_function_args):
+        *return_middle_frame_function_args,
+        interpolation_states: typing.Optional[list[bool]] = None):
     
     output_frames = []  # List to store processed frames in the correct order
 
     number_of_frames_processed_since_last_cleared_cuda_cache = 0
     
     for frame_itr in range(len(frames) - 1): # Skip the final frame since there are no frames after it
-        frame_0 = frames[frame_itr]
-        output_frames.append(frame_0) # Start with first frame
-        
-        # Generate and append a batch of middle frames
-        middle_frames_batch = []
-
-        # Generate and append a middle frame per multiplier - 1
-        for middle_i in range(1, multiplier):
-            timestep = middle_i/multiplier
+        if interpolation_states is not None and interpolation_states[frame_itr]:
+            frame_0 = frames[frame_itr]
+            output_frames.append(frame_0) # Start with first frame
             
-            middle_frame = return_middle_frame_function(
-                frame_0, 
-                frames[frame_itr + 1],
-                timestep,
-                *return_middle_frame_function_args
-            )
-            middle_frames_batch.append(middle_frame)
-            
-        # Extend output array by batch
-        output_frames.extend(middle_frames_batch)
-
-        # Try to avoid a memory overflow by clearing cuda cache regularly
-        if number_of_frames_processed_since_last_cleared_cuda_cache >= clear_cache_after_n_frames:
-            torch.cuda.empty_cache()
-            number_of_frames_processed_since_last_cleared_cuda_cache = 0
+            # Generate and append a batch of middle frames
+            middle_frames_batch = []
+    
+            # Generate and append a middle frame per multiplier - 1
+            for middle_i in range(1, multiplier):
+                timestep = middle_i/multiplier
+                
+                middle_frame = return_middle_frame_function(
+                    frame_0, 
+                    frames[frame_itr + 1],
+                    timestep,
+                    *return_middle_frame_function_args
+                )
+                middle_frames_batch.append(middle_frame)
+                
+            # Extend output array by batch
+            output_frames.extend(middle_frames_batch)
+    
+            # Try to avoid a memory overflow by clearing cuda cache regularly
+            if number_of_frames_processed_since_last_cleared_cuda_cache >= clear_cache_after_n_frames:
+                torch.cuda.empty_cache()
+                number_of_frames_processed_since_last_cleared_cuda_cache = 0
                 
     output_frames.append(frames[-1]) # Append final frame
     out = torch.cat(output_frames, dim=0)

--- a/utils.py
+++ b/utils.py
@@ -107,7 +107,7 @@ def generic_frame_loop(
     number_of_frames_processed_since_last_cleared_cuda_cache = 0
     
     for frame_itr in range(len(frames) - 1): # Skip the final frame since there are no frames after it
-        if interpolation_states is not None and interpolation_states[frame_itr]:
+        if interpolation_states is None or interpolation_states[frame_itr]:
             frame_0 = frames[frame_itr]
             output_frames.append(frame_0) # Start with first frame
             

--- a/utils.py
+++ b/utils.py
@@ -107,9 +107,11 @@ def generic_frame_loop(
     number_of_frames_processed_since_last_cleared_cuda_cache = 0
     
     for frame_itr in range(len(frames) - 1): # Skip the final frame since there are no frames after it
+       
+        frame_0 = frames[frame_itr]
+        output_frames.append(frame_0) # Start with first frame
+        
         if interpolation_states is None or interpolation_states[frame_itr]:
-            frame_0 = frames[frame_itr]
-            output_frames.append(frame_0) # Start with first frame
             
             # Generate and append a batch of middle frames
             middle_frames_batch = []


### PR DESCRIPTION
Still gotta get to the rest at some point. Here are some stats.

Interpolation times in seconds 

AMD Ryzen 9 7945HX
RTX 4090 Laptop GPU GDDR6 @ 16GB (256 bits)

512x512, 18 latents, x6 multiplier, cache cleared every 10 iterations
skipping interpolation models with poor quality (stepping, unnatural motion, not smooth)

Speed is contingent on not only the type of interpolation model, but also number of base latents, 
latent resolution after upscaling, and frame multiplier.

You may be able to achieve better speeds with higher values for 
clear_cache_after_n_frames at the risk of memory overflow. 
1 is very safe and very slow. Good for low-end GPUs. 
High end GPUs can get away with up to 200, depending on the frame multiplier and latent resolution.
Most users with a 3060 or higher should have good results with 30-40, depending on the multiplier and latent resolution..
Jobs with fewer input latents than clear_cache_after_n_frames will only clear the cache once after the job.
You aren't likely to notice much difference with small jobs.

GMFSS Fortuna Union: 5.99

RIFE (42 or 44 appears to offer best time to quality ratio, especially with fast_mode and ensemble both on)---
fast_mode off, ensemble off--
rife41.pth: 1.98
rife42.pth: 2.03
rife43.pth: 2.13
rife44.pth: 2.09

fast_mode on, ensemble off--
rife41.pth: 1.74
rife42.pth: 2.03
rife43.pth: 2.03
rife44.pth: 2.07

fast_mode off, ensemble on--
rife41.pth: 1.78
rife42.pth: 1.72
rife43.pth: 1.76
rife44.pth: 1.72

fast_mode on, ensemble on--
rife41.pth: 1.68
rife42.pth: 1.62
rife43.pth: 1.72
rife44.pth: 1.65