### PR TITLE
Improve memory management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ComfyUI Frame Interpolation (ComfyUI VFI) (WIP)
 
 A custom node set for Video Frame Interpolation in ComfyUI.
+**UPDATE** Memory management is improved. Now this extension takes less RAM and VRAM than before.
 
 ## Nodes
 * KSampler Gradually Adding More Denoise (efficient)

--- a/vfi_models/amt/__init__.py
+++ b/vfi_models/amt/__init__.py
@@ -28,7 +28,6 @@ CKPT_CONFIGS = {
 }
 
 
-
 MODEL_TYPE = pathlib.Path(__file__).parent.name
 
 class AMT_VFI:
@@ -43,6 +42,7 @@ class AMT_VFI:
             },
             "optional": {
                 "optional_interpolation_states": ("INTERPOLATION_STATES", ),
+                "cache_in_fp16": ("BOOLEAN", {"default": True})
             }
         }
     
@@ -56,7 +56,8 @@ class AMT_VFI:
         frames: torch.Tensor, 
         clear_cache_after_n_frames: typing.SupportsInt = 1,
         multiplier: typing.SupportsInt = 2,
-        optional_interpolation_states: InterpolationStateList = None
+        optional_interpolation_states: InterpolationStateList = None,
+        cache_in_fp16: bool = True
     ):
         model_path = load_file_from_direct_url(MODEL_TYPE, f"https://huggingface.co/lalala125/AMT/resolve/main/{ckpt_name}")
         ckpt_config = CKPT_CONFIGS[ckpt_name]
@@ -80,7 +81,7 @@ class AMT_VFI:
         
         args = [interpolation_model]
         out = generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
-                               interpolation_states=optional_interpolation_states)
+                               interpolation_states=optional_interpolation_states, dtype=torch.float16 if cache_in_fp16 else torch.float32)
         out = padder.unpad(out)
         out = postprocess_frames(out)
         return (out,)

--- a/vfi_models/cain/__init__.py
+++ b/vfi_models/cain/__init__.py
@@ -21,6 +21,7 @@ class CAIN_VFI:
             },
             "optional": {
                 "optional_interpolation_states": ("INTERPOLATION_STATES", ),
+                "cache_in_fp16": ("BOOLEAN", {"default": True})
             }
         }
     
@@ -34,7 +35,8 @@ class CAIN_VFI:
         frames: torch.Tensor, 
         clear_cache_after_n_frames: typing.SupportsInt = 1,
         multiplier: typing.SupportsInt = 2,
-        optional_interpolation_states: InterpolationStateList = None
+        optional_interpolation_states: InterpolationStateList = None,
+        cache_in_fp16: bool = True
     ):
         from .cain_arch import CAIN
         model_path = load_file_from_github_release(MODEL_TYPE, ckpt_name)
@@ -58,6 +60,6 @@ class CAIN_VFI:
         args = [interpolation_model]
         out = postprocess_frames(
             generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
-                               interpolation_states=optional_interpolation_states, use_timestep=False)
+                               interpolation_states=optional_interpolation_states, use_timestep=False, dtype=torch.float16 if cache_in_fp16 else torch.float32)
         )
         return (out,)

--- a/vfi_models/eisai/__init__.py
+++ b/vfi_models/eisai/__init__.py
@@ -51,6 +51,7 @@ class EISAI_VFI:
             },
             "optional": {
                 "optional_interpolation_states": ("INTERPOLATION_STATES", ),
+                "cache_in_fp16": ("BOOLEAN", {"default": True})
             }
         }
 
@@ -64,13 +65,12 @@ class EISAI_VFI:
         frames: torch.Tensor,
         clear_cache_after_n_frames = 10,
         multiplier: typing.SupportsInt = 2,
-        optional_interpolation_states: InterpolationStateList = None   
+        optional_interpolation_states: InterpolationStateList = None,
+        cache_in_fp16: bool = True
     ):
         interpolation_model = EISAI(MODEL_FILE_NAMES)
         interpolation_model.eval().to(get_torch_device())
-        
         frames = preprocess_frames(frames)
-
         
         def return_middle_frame(frame_0, frame_1, timestep, model):
             return model(frame_0, frame_1, t=timestep)
@@ -80,6 +80,6 @@ class EISAI_VFI:
         args = [interpolation_model, scale]
         out = postprocess_frames(
             generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
-                               interpolation_states=optional_interpolation_states)
+                               interpolation_states=optional_interpolation_states, dtype=torch.float16 if cache_in_fp16 else torch.float32)
         )
         return (out,)

--- a/vfi_models/gmfss_fortuna/__init__.py
+++ b/vfi_models/gmfss_fortuna/__init__.py
@@ -88,6 +88,7 @@ class GMFSS_Fortuna_VFI:
             },
             "optional": {
                 "optional_interpolation_states": ("INTERPOLATION_STATES", ),
+                "cache_in_fp16": ("BOOLEAN", {"default": True})
             }
         }
     
@@ -101,7 +102,8 @@ class GMFSS_Fortuna_VFI:
         frames: torch.Tensor,
         clear_cache_after_n_frames = 10,
         multiplier: typing.SupportsInt = 2,
-        optional_interpolation_states: InterpolationStateList = None   
+        optional_interpolation_states: InterpolationStateList = None,
+        cache_in_fp16: bool = True
     ):
         """
         Perform video frame interpolation using a given checkpoint model.
@@ -127,10 +129,8 @@ class GMFSS_Fortuna_VFI:
         
         interpolation_model = CommonModelInference(model_type=ckpt_name)
         interpolation_model.eval().to(get_torch_device())
-        
         frames = preprocess_frames(frames)
 
-        
         def return_middle_frame(frame_0, frame_1, timestep, model, scale):
             return model(frame_0, frame_1, timestep, scale)
         
@@ -139,6 +139,6 @@ class GMFSS_Fortuna_VFI:
         args = [interpolation_model, scale]
         out = postprocess_frames(
             generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
-                               interpolation_states=optional_interpolation_states)
+                               interpolation_states=optional_interpolation_states, dtype=torch.float16 if cache_in_fp16 else torch.float32)
         )
         return (out,)

--- a/vfi_models/ifunet/__init__.py
+++ b/vfi_models/ifunet/__init__.py
@@ -22,6 +22,7 @@ class IFUnet_VFI:
             },
             "optional": {
                 "optional_interpolation_states": ("INTERPOLATION_STATES", ),
+                "cache_in_fp16": ("BOOLEAN", {"default": True})
             }
         }
     
@@ -37,16 +38,15 @@ class IFUnet_VFI:
         multiplier: typing.SupportsInt = 2,
         scale_factor: typing.SupportsFloat = 1.0,
         ensemble: bool = True,
-        optional_interpolation_states: InterpolationStateList = None
+        optional_interpolation_states: InterpolationStateList = None,
+        cache_in_fp16: bool = True
     ):
         from .IFUNet_arch import IFUNetModel
         model_path = load_file_from_github_release(MODEL_TYPE, ckpt_name)
         interpolation_model = IFUNetModel()
         interpolation_model.load_state_dict(torch.load(model_path))
         interpolation_model.eval().to(get_torch_device())
-
         frames = preprocess_frames(frames)
-    
         
         def return_middle_frame(frame_0, frame_1, timestep, model, scale_factor, ensemble):
             return model(frame_0, frame_1, timestep=timestep, scale=scale_factor, ensemble=ensemble)
@@ -54,7 +54,7 @@ class IFUnet_VFI:
         args = [interpolation_model, scale_factor, ensemble]
         out = postprocess_frames(
             generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
-                               interpolation_states=optional_interpolation_states)
+                               interpolation_states=optional_interpolation_states, dtype=torch.float16 if cache_in_fp16 else torch.float32)
         )
         return (out,)
         

--- a/vfi_models/rife/__init__.py
+++ b/vfi_models/rife/__init__.py
@@ -46,6 +46,7 @@ class RIFE_VFI:
             },
             "optional": {
                 "optional_interpolation_states": ("INTERPOLATION_STATES", ),
+                "cache_in_fp16": ("BOOLEAN", {"default": True})
             }
         }
     
@@ -62,7 +63,8 @@ class RIFE_VFI:
         fast_mode = False,
         ensemble = False,
         scale_factor = 1.0,
-        optional_interpolation_states: InterpolationStateList = None    
+        optional_interpolation_states: InterpolationStateList = None,
+        cache_in_fp16: bool = True
     ):
         """
         Perform video frame interpolation using a given checkpoint model.
@@ -91,9 +93,7 @@ class RIFE_VFI:
         interpolation_model = IFNet(arch_ver=arch_ver)
         interpolation_model.load_state_dict(torch.load(model_path))
         interpolation_model.eval().to(get_torch_device())
-        
         frames = preprocess_frames(frames)
-
         
         def return_middle_frame(frame_0, frame_1, timestep, model, scale_list, in_fast_mode, in_ensemble):
             return model(frame_0, frame_1, timestep, scale_list, in_fast_mode, in_ensemble)
@@ -103,6 +103,6 @@ class RIFE_VFI:
         args = [interpolation_model, scale_list, fast_mode, ensemble]
         out = postprocess_frames(
             generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
-                               interpolation_states=optional_interpolation_states)
+                               interpolation_states=optional_interpolation_states, dtype=torch.float16 if cache_in_fp16 else torch.float32)
         )
         return (out,)

--- a/vfi_models/sepconv/__init__.py
+++ b/vfi_models/sepconv/__init__.py
@@ -22,6 +22,7 @@ class SepconvVFI:
             },
             "optional": {
                 "optional_interpolation_states": ("INTERPOLATION_STATES", ),
+                "cache_in_fp16": ("BOOLEAN", {"default": True})
             }
         }
     
@@ -35,14 +36,14 @@ class SepconvVFI:
         frames: torch.Tensor,
         clear_cache_after_n_frames = 10,
         multiplier: typing.SupportsInt = 2,
-        optional_interpolation_states: InterpolationStateList = None
+        optional_interpolation_states: InterpolationStateList = None,
+        cache_in_fp16: bool = True
     ):
         from .sepconv_enhanced import Network
         model_path = load_file_from_github_release(MODEL_TYPE, ckpt_name)
         interpolation_model = Network()
         interpolation_model.load_state_dict(torch.load(model_path))
         interpolation_model.eval().to(get_torch_device())
-
         frames = preprocess_frames(frames)
         
         def return_middle_frame(frame_0, frame_1, timestep, model):
@@ -51,6 +52,6 @@ class SepconvVFI:
         args = [interpolation_model]
         out = postprocess_frames(
             generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
-                               interpolation_states=optional_interpolation_states, use_timestep=False)
+                               interpolation_states=optional_interpolation_states, use_timestep=False, dtype=torch.float16 if cache_in_fp16 else torch.float32)
         )
         return (out,)

--- a/vfi_utils.py
+++ b/vfi_utils.py
@@ -181,16 +181,15 @@ def generic_frame_loop(
         number_of_frames_processed_since_last_cleared_cuda_cache += 1
         # Try to avoid a memory overflow by clearing cuda cache regularly
         if number_of_frames_processed_since_last_cleared_cuda_cache >= clear_cache_after_n_frames:
-            print("Comfy-VFI: Clearing cache...")
+            print("Comfy-VFI: Clearing cache...", end=' ')
             soft_empty_cache()
             number_of_frames_processed_since_last_cleared_cuda_cache = 0
-            print("Comfy-VFI: Done cache clearing")
+            print("Done cache clearing")
         
         gc.collect()
     
-    print("Comfy-VFI done!")
-    print(f"{len(output_frames)} frames generated at resolution: {output_frames[0].shape}")
-    output_frames.append(frames[-1:]) # Append final frame
+    print(f"Comfy-VFI done! {len(output_frames)} frames generated at resolution: {output_frames[0].shape}")
+    output_frames.append(frames[-1:].to(dtype=dtype)) # Append final frame
     output_frames = [frame.cpu() for frame in output_frames] #Ensure all frames are in cpu
     out = torch.cat(output_frames, dim=0)
     # clear cache for courtesy


### PR DESCRIPTION
Very minor tweaks to avoid running out of regular RAM memory:
- store the frames in float16 instead of float32
- do occasional garbage collection
- print out final n_frames / resolution