### PR TITLE
Reduce the RAM consumption of RIFE VFI by 2x

### DIFF
--- a/vfi_models/rife/__init__.py
+++ b/vfi_models/rife/__init__.py
@@ -102,6 +102,6 @@ class RIFE_VFI:
         args = [interpolation_model, scale_list, fast_mode, ensemble]
         out = postprocess_frames(
             generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
-                               interpolation_states=optional_interpolation_states, dtype=torch.float16)
+                               interpolation_states=optional_interpolation_states, dtype=torch.float32)
         )
         return (out,)

--- a/vfi_models/rife/__init__.py
+++ b/vfi_models/rife/__init__.py
@@ -102,6 +102,6 @@ class RIFE_VFI:
         args = [interpolation_model, scale_list, fast_mode, ensemble]
         out = postprocess_frames(
             generic_frame_loop(frames, clear_cache_after_n_frames, multiplier, return_middle_frame, *args, 
-                               interpolation_states=optional_interpolation_states, dtype=torch.float32)
+                               interpolation_states=optional_interpolation_states, dtype=torch.float16)
         )
         return (out,)


### PR DESCRIPTION
Problem I am trying to fix:
My computer has 32 GB RAM. For a video with 24 fps, 160 second long, 1024 * 768  at float32 resolution, it takes (4*3*1024*576)*(160*24)/1024/1024/1024 = 25.4GB memory. And the original code crashes at line 194 `out = torch.cat(output_frames, dim=0)` because it's trying to allocate the same amount of memory to convert the list of tensor to a single tensor.

Fix: 
+ Avoided torch.cat() by pre-allocating this tensor, and then write directly to this tensor . In this way we can avoid the copying. This reduces RAM consumption by 2x.
+ ~Changed the RIFE's dtype to store the output frames from float32 to float16 (this PR only changes that for VFI, but I am happy to change for all other models as well in this PR if you see fit). This reduces RAM consumption by 2x.~ removed according to comments below.