### PR TITLE
MPS: Unsupported Border padding mode

### DIFF
--- a/vfi_models/rife/rife_arch.py
+++ b/vfi_models/rife/rife_arch.py
@@ -56,11 +56,15 @@ def warp(tenInput, tenFlow):
     if tenInput.type() == "torch.cuda.HalfTensor":
         g = g.half()
 
+    padding_mode = 'border'
+    if device.type == "mps":
+        padding_mode = 'zeros'
+        g = g.clamp(-1, 1)
     return torch.nn.functional.grid_sample(
         input=tenInput,
         grid=g,
         mode="bilinear",
-        padding_mode="border",
+        padding_mode=padding_mode,
         align_corners=True,
     )
 

--- a/vfi_models/rife/rife_arch.py
+++ b/vfi_models/rife/rife_arch.py
@@ -56,9 +56,10 @@ def warp(tenInput, tenFlow):
     if tenInput.type() == "torch.cuda.HalfTensor":
         g = g.half()
 
-    padding_mode = 'border'
+    padding_mode = "border"
     if device.type == "mps":
-        padding_mode = 'zeros'
+        # https://github.com/pytorch/pytorch/issues/125098
+        padding_mode = "zeros"
         g = g.clamp(-1, 1)
     return torch.nn.functional.grid_sample(
         input=tenInput,


### PR DESCRIPTION
This update ensures that when using `F.grid_sample`, the grid tensor values are clamped within the range of [-1, 1] for devices using MPS (Metal Performance Shaders).

Fixes: https://github.com/Fannovel16/ComfyUI-Frame-Interpolation/issues/47
