### PR TITLE
fix: add HuggingFace fallback URL for model downloads

### DIFF
--- a/vfi_utils.py
+++ b/vfi_utils.py
@@ -14,7 +14,8 @@ import numpy as np
 BASE_MODEL_DOWNLOAD_URLS = [
     "https://github.com/styler00dollar/VSGAN-tensorrt-docker/releases/download/models/",
     "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation/releases/download/models/",
-    "https://github.com/dajes/frame-interpolation-pytorch/releases/download/v1.0.0/"
+    "https://github.com/dajes/frame-interpolation-pytorch/releases/download/v1.0.0/",
+    "https://huggingface.co/Isi99999/Frame_Interpolation_Models/resolve/main/"
 ]
 
 config_path = os.path.join(os.path.dirname(__file__), "./config.yaml")


### PR DESCRIPTION
All three existing GitHub download endpoints for model files (e.g. rife49.pth) return HTTP 404. This PR adds HuggingFace as a fallback endpoint.\n\nFixes #117