### PR TITLE
🚀 Feature: Update RIFE node display name to recommend 4.25+ versions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -42,7 +42,7 @@ NODE_CLASS_MAPPINGS = {
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "RIFE VFI": "RIFE VFI (recommend rife47 and rife49)",
+    "RIFE VFI": "RIFE VFI (recommend rife4.25+)",
     "ATM VFI": "ATM VFI (only supports 2x multiplier)",
     "MOMO VFI": "MOMO VFI (only supports 2x multiplier)"
 }


### PR DESCRIPTION
## Problem

Update the NODE_DISPLAY_NAME_MAPPINGS to recommend the newer RIFE 4.25+ versions instead of just 4.7 and 4.9.

**Severity**: `low`
**File**: `__init__.py`

## Solution

Update the NODE_DISPLAY_NAME_MAPPINGS to recommend the newer RIFE 4.25+ versions instead of just 4.7 and 4.9.

## Changes

- `__init__.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #125